### PR TITLE
Add a link to PDC Base Fields sheet

### DIFF
--- a/src/generateApplicationFormJson.ts
+++ b/src/generateApplicationFormJson.ts
@@ -1,4 +1,6 @@
-// Takes a csv file and creates a JSON body for POST /applicationForms.
+// Takes a comma-separated values (CSV) file and creates a JSON body for POST /applicationForms.
+// The CSV is usually derived from the following URL using xlsx export and `xslx2csv`:
+// https://docs.google.com/spreadsheets/d/1Ep3_MEIyIbhxJ5TpH5x4Q1fRZqr1CFHXZ_uv3fEOSEk
 import fs from 'fs';
 import CsvReadableStream from 'csv-reader';
 import { parse } from 'ts-command-line-args';

--- a/src/generateBaseFieldsInserts.ts
+++ b/src/generateBaseFieldsInserts.ts
@@ -1,4 +1,6 @@
-// Takes a comma-separated values file and creates a base fields INSERT SQL file.
+// Takes a comma-separated values (CSV) file and creates a canonical fields INSERT SQL file.
+// The CSV is usually derived from the following URL using xlsx export and `xslx2csv`:
+// https://docs.google.com/spreadsheets/d/1Ep3_MEIyIbhxJ5TpH5x4Q1fRZqr1CFHXZ_uv3fEOSEk
 import fs from 'fs';
 import os from 'os';
 import CsvReadableStream from 'csv-reader';


### PR DESCRIPTION
This makes it easier to find the original source of data that these scripts use. This helps people that are looking at the base fields in the PDC as well as people trying to exercise these scripts locally.