### PR TITLE
Fail linting if any warnings are encountered

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "dist/generateBaseFieldsInserts.js",
   "scripts": {
-    "lint": "eslint ./src --ext .ts",
+    "lint": "eslint ./src --ext .ts --max-warnings=0",
     "test": "echo \"no tests\" && exit 1",
     "generateBaseFieldsInserts": "ts-node src/generateBaseFieldsInserts",
     "generateApplicationFormJson": "ts-node src/generateApplicationFormJson"

--- a/src/generateApplicationFormJson.ts
+++ b/src/generateApplicationFormJson.ts
@@ -93,5 +93,6 @@ axios(`${apiUrl}/baseFields`, {
     jsonOutput.close();
   });
 }).catch((error: AxiosError) => {
+  // eslint-disable-next-line no-console
   console.log(error.response?.data);
 });


### PR DESCRIPTION
Update the way we run ESLint to [specify that we want zero warnings](https://eslint.org/docs/latest/use/command-line-interface#--max-warnings), and any more than that should return an error code.

Ignore the existing warning for now.