### PR TITLE
Use `csv-parse`'s sync API throughout the scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "axios": "^1.4.0",
         "csv-parse": "^5.4.0",
-        "csv-reader": "^1.0.12",
         "pino": "^8.14.1",
         "pino-pretty": "^10.0.0",
         "ts-command-line-args": "^2.5.1"
@@ -914,14 +913,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.4.0.tgz",
       "integrity": "sha512-JiQosUWiOFgp4hQn0an+SBoV9IKdqzhROM0iiN4LB7UpfJBlsSJlWl9nq4zGgxgMAzHJ6V4t29VAVD+3+2NJAg=="
-    },
-    "node_modules/csv-reader": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/csv-reader/-/csv-reader-1.0.12.tgz",
-      "integrity": "sha512-0AAgazKJUywtjvZbclNuovIiQY/WyvojWw15Y2k3kPixE+pDiOFnfg5FcH3CfDqqnrB2f3p5oPAc446EXD01Tw==",
-      "engines": {
-        "node": ">=8.0.0"
-      }
     },
     "node_modules/dateformat": {
       "version": "4.6.3",
@@ -4125,11 +4116,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.4.0.tgz",
       "integrity": "sha512-JiQosUWiOFgp4hQn0an+SBoV9IKdqzhROM0iiN4LB7UpfJBlsSJlWl9nq4zGgxgMAzHJ6V4t29VAVD+3+2NJAg=="
-    },
-    "csv-reader": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/csv-reader/-/csv-reader-1.0.12.tgz",
-      "integrity": "sha512-0AAgazKJUywtjvZbclNuovIiQY/WyvojWw15Y2k3kPixE+pDiOFnfg5FcH3CfDqqnrB2f3p5oPAc446EXD01Tw=="
     },
     "dateformat": {
       "version": "4.6.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "axios": "^1.4.0",
-    "csv-reader": "^1.0.12",
     "csv-parse": "^5.4.0",
     "pino": "^8.14.1",
     "pino-pretty": "^10.0.0",

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -1,0 +1,13 @@
+import { AssertionError } from 'assert';
+
+export type CsvRow = Record<string, string>;
+
+export function assertIsCsvRow(row: unknown): asserts row is CsvRow {
+  if (row === null
+    || typeof row !== 'object'
+    || Object.keys(row).length === 0
+    || Object.keys(row).some((key) => typeof key !== 'string')
+    || Object.values(row).some((value) => typeof value !== 'string')) {
+    throw new AssertionError({ message: 'Given row is not a CsvRow!' });
+  }
+}

--- a/src/postProposalVersions.ts
+++ b/src/postProposalVersions.ts
@@ -1,10 +1,11 @@
 // Takes a CSV file, creates JSON bodies for POST /proposalVersions, posts them.
 import { readFileSync } from 'fs';
-import { AssertionError } from 'assert';
 import { parse as csvParse } from 'csv-parse/sync';
 import { parse as argParse } from 'ts-command-line-args';
 import axios, { AxiosError } from 'axios';
+import { assertIsCsvRow } from './csv';
 import { logger } from './logger';
+import type { CsvRow } from './csv';
 
 interface Args {
   inputFile: string;
@@ -13,18 +14,6 @@ interface Args {
   proposalExternalIdColumnName: string;
   bearerToken: string;
   apiUrl: string;
-}
-
-type CsvRow = Record<string, string>;
-
-function assertIsCsvRow(row: unknown): asserts row is CsvRow {
-  if (row === null
-    || typeof row !== 'object'
-    || Object.keys(row).length === 0
-    || Object.keys(row).some((key) => typeof key !== 'string')
-    || Object.values(row).some((value) => typeof value !== 'string')) {
-    throw new AssertionError({ message: 'Given row is not a CsvRow!' });
-  }
 }
 
 interface Applicant {


### PR DESCRIPTION
Without this change there would be two CSV reading libraries in use and two scripts would continue to have race conditions. We do not need the sophistication of a stream API because we have yet to see any CSVs larger than a few MiB. This change uses the technique already present in the `postProposalVersions.ts` script in the older two scripts.

Because there would be repeated boilerplate otherwise, a new `csv.ts` has the commonly used type and type assertion guard.

Issue #25 Race between row and EOF events for forms and proposals