### PR TITLE
Add Contributing and Code of Conduct guides

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+If you're interested in contributing to this project,
+please read the
+[general PDC code of conduct](https://github.com/PhilanthropyDataCommons/.github/blob/main/CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+If you're interested in contributing to this project,
+please start with the
+[general PDC contribution guidelines](https://github.com/PhilanthropyDataCommons/.github/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
Each repository in PhilanthropyDataCommons should point to a single pair of guides for PDC in its `.github` repository.

See https://github.com/PhilanthropyDataCommons/front-end/issues/251