### PR TITLE
Get Charity Navigator data for existing EINs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Candid Premier API subscription key
 DS_CANDID_API_KEY=my-candid-api-key
 
+# Candid Premier API subscription key
+DS_CHARITY_NAVIGATOR_API_KEY=my-charity-navigator-api-key
+
 # Location of OpenID Connect authority
 DS_OIDC_BASE_URL=https://auth.philanthropydatacommons.org/realms/pdc
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
+        "@apollo/client": "^4.0.11",
         "@tsconfig/node24": "^24.0.3",
         "axios": "^1.13.1",
         "csv-parse": "^5.5.6",
@@ -21,6 +22,7 @@
         "yargs": "^17.7.2"
       },
       "devDependencies": {
+        "@pdc/sdk": "^0.26.1",
         "@types/node": "^24.10.1",
         "@types/yargs": "^17.0.32",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
@@ -42,6 +44,54 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@apollo/client": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.0.11.tgz",
+      "integrity": "sha512-jyW5j3DEYnFlYA1Lk9Szd7O/od1DptnbZnj03DQXxuQb+Gnop0w/uQxVRKaU7bPhvVuBnlAtZYPOykArX+xWdg==",
+      "license": "MIT",
+      "workspaces": [
+        "dist",
+        "codegen",
+        "scripts/codemods/ac3-to-ac4"
+      ],
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/caches": "^1.0.0",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.5.0",
+        "graphql-tag": "^2.12.6",
+        "optimism": "^0.18.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^16.0.0",
+        "graphql-ws": "^5.5.5 || ^6.0.3",
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "react-dom": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "rxjs": "^7.3.0",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@apollo/client/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -111,6 +161,15 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -209,6 +268,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@pdc/sdk": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.26.1.tgz",
+      "integrity": "sha512-NT/qq/oHGD1izMgJWO3l6H0ClZS5uyD79ux7pgbxKTJERWhhLTGZ6Nfnck6c1xH1q1KWiO4HWZHMtWB1cBZ0xQ==",
+      "dev": true,
+      "license": "AGPL-3.0"
     },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
@@ -492,6 +558,78 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@wry/caches": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
+      "integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/caches/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@wry/context": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
+      "integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/context/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@wry/equality": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/equality/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@wry/trie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+      "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/trie/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/acorn": {
       "version": "8.10.0",
@@ -2180,6 +2318,37 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
+    "node_modules/graphql": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/graphql-tag/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -3083,6 +3252,24 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/optimism": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
+      "integrity": "sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@wry/caches": "^1.0.0",
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.5.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/optimism/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/optionator": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -3512,6 +3699,21 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/rxjs/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -4429,6 +4631,27 @@
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "dev": true
     },
+    "@apollo/client": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.0.11.tgz",
+      "integrity": "sha512-jyW5j3DEYnFlYA1Lk9Szd7O/od1DptnbZnj03DQXxuQb+Gnop0w/uQxVRKaU7bPhvVuBnlAtZYPOykArX+xWdg==",
+      "requires": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/caches": "^1.0.0",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.5.0",
+        "graphql-tag": "^2.12.6",
+        "optimism": "^0.18.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -4475,6 +4698,12 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
       "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true
+    },
+    "@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "requires": {}
     },
     "@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -4546,6 +4775,12 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@pdc/sdk": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.26.1.tgz",
+      "integrity": "sha512-NT/qq/oHGD1izMgJWO3l6H0ClZS5uyD79ux7pgbxKTJERWhhLTGZ6Nfnck6c1xH1q1KWiO4HWZHMtWB1cBZ0xQ==",
+      "dev": true
     },
     "@pinojs/redact": {
       "version": "0.4.0",
@@ -4736,6 +4971,66 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true
+    },
+    "@wry/caches": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
+      "integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
+    "@wry/context": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
+      "integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
+    "@wry/equality": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
+    "@wry/trie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+      "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
     },
     "acorn": {
       "version": "8.10.0",
@@ -5980,6 +6275,27 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
+    "graphql": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
+      "peer": true
+    },
+    "graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
     "has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -6594,6 +6910,24 @@
         "oidc-token-hash": "^5.0.3"
       }
     },
+    "optimism": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
+      "integrity": "sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==",
+      "requires": {
+        "@wry/caches": "^1.0.0",
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.5.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
     "optionator": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -6872,6 +7206,21 @@
       "dev": true,
       "requires": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
       }
     },
     "safe-array-concat": {

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
     "start": "ts-node src/index",
     "generateBaseFieldsInserts": "ts-node src/generateBaseFieldsInserts",
     "generateApplicationFormJson": "ts-node src/generateApplicationFormJson",
-    "postProposalVersions": "ts-node src/postProposalVersions"
+    "postProposalVersions": "ts-node src/postProposalVersions",
+    "charityNavigator": "ts-node src/index charityNavigator"
   },
-  "author": "",
+  "author": "Open Tech Strategies",
   "license": "AGPL-3.0-or-later",
   "devDependencies": {
+    "@pdc/sdk": "^0.26.1",
     "@types/node": "^24.10.1",
     "@types/yargs": "^17.0.32",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
@@ -27,6 +29,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
+    "@apollo/client": "^4.0.11",
     "@tsconfig/node24": "^24.0.3",
     "axios": "^1.13.1",
     "csv-parse": "^5.5.6",

--- a/src/candid.ts
+++ b/src/candid.ts
@@ -1,8 +1,9 @@
 import { writeFile } from 'fs/promises';
 import { client } from './client';
+import { isValidEin } from './ein';
 import { logger } from './logger';
 import { getToken, oidcOptions } from './oidc';
-import { getBaseFields, getProposals, postPlatformProviderData } from './pdc-api';
+import { getProposals, postPlatformProviderData } from './pdc-api';
 import type { CommandModule } from 'yargs';
 import type { AccessTokenSet } from './oidc';
 
@@ -28,10 +29,6 @@ const getCandidProfile = async (
   logger.debug(`Fetched Candid data for ${ein}: ${data.message}`);
   return data;
 };
-
-const isValidEin = (s: string): boolean => (
-  /^\d{2}-?\d{7}$/.test(s)
-);
 
 interface LookupCommandArgs {
   'candid-api-key': string;
@@ -119,28 +116,13 @@ const updateCommand: CommandModule = {
   },
 };
 
-const getEinBaseFieldId = async (
-  baseUrl: string,
-  token: AccessTokenSet,
-) => {
-  const baseFields = await getBaseFields(baseUrl, token);
-  const einBaseField = baseFields.find(({ shortCode }) => (
-    shortCode === 'organization_tax_id'
-  ));
-  if (einBaseField === undefined) {
-    throw new Error('Could not find base field with short code `organization_tax_id`');
-  }
-  return einBaseField.id;
-};
-
 const getEinsFromPdc = async (baseUrl: string, token: AccessTokenSet) => {
-  const einBaseFieldId = await getEinBaseFieldId(baseUrl, token);
   const proposals = await getProposals(baseUrl, token);
 
   const eins = new Set(proposals.entries
     .flatMap((proposal) => proposal.versions[0]?.fieldValues)
     .filter(<T>(x: T | undefined): x is T => typeof x !== 'undefined')
-    .filter(({ applicationFormField }) => applicationFormField.baseFieldId === einBaseFieldId)
+    .filter(({ applicationFormField }) => applicationFormField.baseFieldShortCode === 'organization_tax_id')
     .map(({ value }) => value)
     .filter(isValidEin));
   return [...eins];

--- a/src/charityNavigator.ts
+++ b/src/charityNavigator.ts
@@ -1,0 +1,344 @@
+import { writeFile } from 'fs/promises';
+import {
+  ApolloClient, InMemoryCache, TypedDocumentNode, gql,
+} from '@apollo/client';
+import { SetContextLink } from '@apollo/client/link/context';
+import { HttpLink } from '@apollo/client/link/http';
+import { isValidEin } from './ein';
+import { logger } from './logger';
+import { AccessTokenSet, getToken, oidcOptions } from './oidc';
+import {
+  getChangemakers, getSources, postChangemakerFieldValue, postChangemakerFieldValueBatch,
+  postSource,
+} from './pdc-api';
+import type { CommandModule } from 'yargs';
+import type { Changemaker, ChangemakerBundle, Source } from '@pdc/sdk';
+
+const CN_SHORT_CODE = 'charitynav';
+
+interface NonprofitPublic {
+  ein: string,
+  name: string,
+  updatedAt: string,
+  website?: string,
+  phone?: string,
+  mission?: string,
+  encompassRatingId?: number,
+  encompassScore?: number,
+  encompassStarRating?: number
+  encompassPublicationDate?: string,
+  size?: string,
+  cause?: string,
+}
+
+/** Map from Charity Navigator NonprofitPublic attribute name to PDC base field name */
+const baseFieldMap = {
+  name: 'organization_name',
+  website: 'organization_website',
+  phone: 'organization_phone',
+  mission: 'organization_mission_statement',
+};
+
+interface PageInfo {
+  totalPages: number;
+  totalItems: number;
+  currentPage: number;
+}
+
+interface NonprofitsPublicResponse {
+  nonprofitsPublic: {
+    edges: NonprofitPublic[];
+    pageInfo: PageInfo;
+  };
+}
+
+interface NonprofitsPublicVariables {
+  perPage?: number;
+  page?: number;
+  resultSize?: number;
+  filter: {
+    ein: {
+      in: string[];
+    };
+  };
+}
+
+const QueryNonprofitsPublic: TypedDocumentNode<
+NonprofitsPublicResponse,
+NonprofitsPublicVariables
+> = gql`
+  query NonprofitsPublic(
+    $perPage: Int!
+    $filter: NonprofitFilters
+  ) {
+    nonprofitsPublic(
+      filter: $filter
+    ) {
+        edges {
+          ein
+          name
+          updatedAt
+          website
+          phone
+          mission
+          encompassRatingId
+          encompassScore
+          encompassStarRating
+          encompassPublicationDate
+          size
+          cause
+        }
+        pageInfo {
+          totalPages
+          totalItems
+          currentPage
+        }
+    }
+  }
+`;
+
+const isNonprofitPublic = (edge: object): edge is NonprofitPublic => {
+  const obj = edge as Record<string, unknown>;
+  return (
+    typeof obj.ein === 'string'
+    && typeof obj.name === 'string'
+    && typeof obj.updatedAt === 'string'
+  );
+};
+
+function apolloInit(apiUrl: string, apiKey: string) {
+  const cache = new InMemoryCache();
+  const authLink = new SetContextLink((prevContext) => ({
+    /* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment --
+    Here is the transitive upstream type definition for prevContext:
+    export interface DefaultContext extends Record<string, any> {...}
+    Therefore apollo defines an `any` type on `headers` through no fault of our own. */
+    headers: {
+      ...prevContext.headers,
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }));
+
+  const httpLinkPrimary = new HttpLink({
+    uri: `${apiUrl}`,
+  });
+  const apolloClient = new ApolloClient({
+    link: authLink.concat(httpLinkPrimary),
+    cache,
+  });
+
+  return apolloClient;
+}
+const API_URL = 'https://api.charitynavigator.org/graphql';
+
+const getCharityNavigatorProfiles = async (
+  apiKey: string,
+  eins: string[],
+): Promise<ApolloClient.QueryResult<NonprofitsPublicResponse>> => {
+  logger.info(`Looking up EINs ${JSON.stringify(eins)} in Charity Navigator GraphQL API`);
+  const apollo = apolloInit(API_URL, apiKey);
+  const variables = {
+    filter: {
+      ein: {
+        in: eins,
+      },
+    },
+    page: 1,
+    resultSize: eins.length,
+  };
+  logger.info(`Fetching charity navigator data for ${JSON.stringify(eins)} using vars ${JSON.stringify(variables)}`);
+  return apollo
+    .query({
+      query: QueryNonprofitsPublic,
+      variables,
+    });
+};
+
+interface LookupCommandArgs {
+  'charity-navigator-api-key'?: string;
+  eins: string[];
+  outputFile?: string;
+}
+
+interface UpdateAllCommandArgs {
+  'charity-navigator-api-key'?: string;
+  'oidc-base-url': string,
+  'oidc-client-id': string,
+  'oidc-client-secret': string,
+  'pdc-api-base-url': string;
+}
+
+const lookupCommand: CommandModule<unknown, LookupCommandArgs> = {
+  command: 'lookup',
+  describe: 'Fetch and display information about organizations by EIN',
+  builder: (y) => (y
+    .option('charity-navigator-api-key', {
+      describe: 'CharityNavigator API key; get from account management at https://developer.charitynavigator.org/ (can also be set via DS_CHARITY_NAVIGATOR_API_KEY env var)',
+      demandOption: false,
+      type: 'string',
+    })
+    .check((argv) => {
+      if (!argv.charityNavigatorApiKey) {
+        throw new Error('Missing required argument: charity-navigator-api-key (set via CLI or DS_CHARITY_NAVIGATOR_API_KEY env var)');
+      }
+      return true;
+    })
+    .option('output-file', {
+      alias: 'write',
+      describe: 'Write organization information to the specified JSON file',
+      normalize: true,
+      type: 'string',
+    })
+    .option('eins', {
+      string: true,
+      describe: 'US tax IDs of organizations to look up',
+      type: 'array',
+      default: [],
+    })
+    .check(({ eins }) => !(new Set(eins.map(isValidEin)).has(false)))
+  ),
+  handler: async (args) => {
+    const { charityNavigatorApiKey: apiKey } = args;
+    if (!apiKey) {
+      throw new Error('Missing required argument: charity-navigator-api-key');
+    }
+    const result = await getCharityNavigatorProfiles(apiKey, args.eins)
+      .catch((err) => {
+        logger.error(err, 'error calling primary graphql api');
+        throw err;
+      });
+
+    if (args.outputFile) {
+      await writeFile(
+        args.outputFile,
+        JSON.stringify(result, null, 2),
+      );
+      logger.info(`Wrote CharityNavigator data for ${JSON.stringify(args.ein)} to ${JSON.stringify(args.outputFile)}`);
+    } else {
+      logger.info({ result }, 'CharityNavigator result');
+    }
+  },
+};
+
+const getChangemakerByEin = (ein: string, changemakers: ChangemakerBundle): Changemaker | null => {
+  // Make the comparison with hyphens stripped.
+  const matches = changemakers.entries.filter((c) => c.taxId.replace('-', '') === ein);
+  if (matches.length > 1) {
+    logger.warn(`Found multiple changemakers with EIN ${ein}, not returning any.`);
+    return null;
+  }
+  if (matches.length < 1) {
+    logger.info(`Found no changemaker with EIN ${ein}`);
+    return null;
+  }
+  if (matches.length === 1 && matches[0] !== undefined) {
+    return matches[0];
+  }
+  throw new Error('How could this have happened?');
+};
+
+const getOrCreateSource = async (baseUrl: string, token: AccessTokenSet): Promise<Source> => {
+  const sources = await getSources(baseUrl, token);
+  const filteredSources = sources.entries.filter((s) => s.dataProviderShortCode === CN_SHORT_CODE);
+  if (filteredSources.length === 1 && filteredSources[0] !== undefined) {
+    // Hurray, an existing Charity Navigator Source was found, return it!
+    return Promise.resolve(filteredSources[0]);
+  }
+  // Create the Charity Navigator Source, we expect/require the Data Provider to exist.
+  logger.warn('Have a `pdc-admin` create a source because only administrators may be able.');
+  // The following may not succeed, doesn't succeed as of this writing.
+  return postSource(baseUrl, token, {
+    dataProviderShortCode: CN_SHORT_CODE,
+    label: 'Charity Navigator',
+  });
+};
+
+const updateAllCommand: CommandModule<unknown, UpdateAllCommandArgs> = {
+  command: 'updateAll',
+  describe: 'For each changemaker present in the PDC, get Charity Navigator data and upload it to PDC.',
+  builder: {
+    ...oidcOptions,
+    'charity-navigator-api-key': {
+      describe: 'CharityNavigator API key; get from account management at https://developer.charitynavigator.org/ (can also be set via DS_CHARITY_NAVIGATOR_API_KEY env var)',
+      demandOption: false,
+      type: 'string',
+    },
+    'pdc-api-base-url': {
+      describe: 'Location of PDC API',
+      demandOption: true,
+      type: 'string',
+    },
+  },
+  handler: async (args) => {
+    const apiKey = args.charityNavigatorApiKey;
+    if (!apiKey) {
+      throw new Error('Missing required argument: charity-navigator-api-key (set via CLI or DS_CHARITY_NAVIGATOR_API_KEY env var)');
+    }
+    const changemakers = await getChangemakers(args.pdcApiBaseUrl);
+    const eins = changemakers.entries.flatMap((c) => c.taxId);
+    // Charity Navigator expects no hyphens, strip them from EINs after validation.
+    const validEins = eins.filter(isValidEin).flatMap((e) => e.replace('-', ''));
+    const invalidEins = eins.filter((e) => !isValidEin(e));
+    if (invalidEins.length > 0) {
+      logger.warn(invalidEins, 'These EINs in PDC are invalid and will not be queried');
+    }
+    logger.info(validEins, 'Found these valid EINs which will be requested from Charity Navigator');
+    const charityNavResponse = await getCharityNavigatorProfiles(
+      apiKey,
+      validEins,
+    );
+    logger.info({ charityNavResponse }, 'CharityNavigator result');
+    // Up to this point we didn't need PDC authentication. Now we do.
+    const token = await getToken(
+      args.oidcBaseUrl,
+      args.oidcClientId,
+      args.oidcClientSecret,
+    );
+    if (!charityNavResponse.data) {
+      logger.warn('No data found');
+      return;
+    }
+    // First, find the existing source. As of this writing, it cannot be created by non-admins.
+    const source = await getOrCreateSource(args.pdcApiBaseUrl, token);
+    logger.info(source, 'The PDC Source for Charity Navigator was found');
+    // Second, post the fields to PDC
+    const { edges } = charityNavResponse.data.nonprofitsPublic;
+    const nonprofits = edges.filter((e): e is NonprofitPublic => isNonprofitPublic(e));
+    logger.info(nonprofits, 'Found these nonprofits');
+    // Third, register a batch of changemaker fields to be posted
+    const fieldBatch = await postChangemakerFieldValueBatch(args.pdcApiBaseUrl, token, { sourceId: source.id, notes: `data-scripts charityNavigator.ts execution ${Date.now()}` });
+    // Last, for each nonprofit, for each field, post the field
+    edges.map(async (e) => {
+      const changemaker = getChangemakerByEin(e.ein, changemakers);
+      if (changemaker !== null) {
+        Object.entries(baseFieldMap).map(async ([cnAttributeName, baseFieldShortCode]) => {
+          const cnAttribute = e[cnAttributeName as keyof NonprofitPublic];
+          /* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition --
+          The cnAttribute can really be null even though types say otherwise  */
+          if (cnAttribute !== undefined && cnAttribute !== null) {
+            const fieldValue = await postChangemakerFieldValue(args.pdcApiBaseUrl, token, {
+              changemakerId: changemaker.id,
+              batchId: fieldBatch.id,
+              baseFieldShortCode,
+              value: cnAttribute.toString(),
+              goodAsOf: e.updatedAt,
+            });
+            logger.info(`Added changemaker field value: ${JSON.stringify(fieldValue)}`);
+          }
+        });
+      }
+    });
+  },
+};
+
+const charityNavigator: CommandModule = {
+  command: 'charityNavigator',
+  describe: 'Interact with the CharityNavigator Premier API',
+  builder: (y) => (y
+    .command(lookupCommand)
+    .command(updateAllCommand)
+    .demandCommand(1)
+  ),
+  handler: () => {},
+};
+export { charityNavigator };

--- a/src/ein.ts
+++ b/src/ein.ts
@@ -1,0 +1,3 @@
+export const isValidEin = (s: string): boolean => (
+  /^\d{2}-?\d{7}$/.test(s)
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { config } from 'dotenv';
 import yargs from 'yargs/yargs';
 import { hideBin } from 'yargs/helpers';
 import { candid } from './candid';
+import { charityNavigator } from './charityNavigator';
 import { logger } from './logger';
 import { getTokenCommand } from './oidc';
 
@@ -31,6 +32,7 @@ const main = async (argv: string[]) => yargs(hideBin(argv))
   )
   .command(getTokenCommand)
   .command(candid)
+  .command(charityNavigator)
   .demandCommand()
   .parse();
 

--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -1,74 +1,164 @@
 import { client } from './client';
 import type { AccessTokenSet } from './oidc';
+import type {
+  BaseField, ProposalBundle, ChangemakerBundle, SourceBundle, Source,
+} from '@pdc/sdk';
 
 const callPdcApi = async <T>(
   baseUrl: string,
   path: string,
   params: Record<string, string>,
-  token: AccessTokenSet,
   method: 'get' | 'post',
+  token?: AccessTokenSet,
   data?: unknown,
 ): Promise<T> => {
   const url = new URL(path, baseUrl);
   url.search = new URLSearchParams(params).toString();
+  const headers = token ? { authorization: `Bearer ${token.access_token}` } : {};
   const response = await client.request<T>(
     {
       method,
       url: url.toString(),
-      headers: {
-        authorization: `Bearer ${token.access_token}`,
-      },
+      headers,
       data,
     },
   );
   return response.data;
 };
 
-interface ApiBaseField {
-  id: number;
-  label: string;
-  shortCode: string;
-}
-
 const getBaseFields = (baseUrl: string, token: AccessTokenSet) => (
-  callPdcApi<ApiBaseField[]>(
+  callPdcApi<BaseField[]>(
     baseUrl,
     '/baseFields',
     {},
-    token,
     'get',
+    token,
   )
 );
 
-interface ApiProposal {
-  id: number;
-  versions: {
-    version: number;
-    fieldValues: {
-      applicationFormField: {
-        baseFieldId: number;
-        position: number;
-      };
-      value: string;
-    }[];
-  }[];
-}
-
-interface ApiProposals {
-  entries: ApiProposal[];
-  total: number;
-}
-
 const getProposals = (baseUrl: string, token: AccessTokenSet) => (
-  callPdcApi<ApiProposals>(
+  callPdcApi<ProposalBundle>(
     baseUrl,
     '/proposals',
     {
       _page: '1',
       _count: '1000',
     },
-    token,
     'get',
+    token,
+  )
+);
+
+/**
+ * Get all (up to 10m) changemakers. Avoids authentication to get only direct attributes (shallow).
+ * The `fields` and `fiscalSponsors` (deep) attributes will be present but empty in this case.
+ */
+const getChangemakers = (baseUrl: string) => (
+  callPdcApi<ChangemakerBundle>(
+    baseUrl,
+    '/changemakers',
+    {
+      _page: '1',
+      _count: '10000000',
+    },
+    'get',
+  )
+);
+
+/**
+ * Get all (up to 1m) sources.
+ */
+const getSources = (baseUrl: string, token: AccessTokenSet) => (
+  callPdcApi<SourceBundle>(
+    baseUrl,
+    '/sources',
+    {
+      _page: '1',
+      _count: '1000000',
+    },
+    'get',
+    token,
+  )
+);
+
+/** A corrected WritableSource (the SDK's is a bit off as of this writing) */
+export interface WritableSource {
+  label: string;
+  dataProviderShortCode: string;
+}
+
+const postSource = (baseUrl: string, token: AccessTokenSet, data: WritableSource) => (
+  callPdcApi<Source>(
+    baseUrl,
+    '/sources',
+    {},
+    'post',
+    token,
+    data,
+  )
+);
+
+// TODO: use the SDK, delete these temp types copied from the service repo
+interface ChangemakerFieldValueBatch {
+  readonly id: number;
+  sourceId: number;
+  notes: string | null;
+  readonly createdAt: string;
+  readonly source: Source;
+}
+interface ChangemakerFieldValue {
+  readonly id: number;
+  changemakerId: number;
+  baseFieldShortCode: string;
+  batchId: number;
+  value: string;
+  readonly file: File | null;
+  goodAsOf: string | null;
+  readonly createdAt: string;
+  readonly baseField: BaseField;
+  readonly batch: ChangemakerFieldValueBatch;
+  readonly isValid: boolean;
+}
+
+interface WritableChangemakerFieldValueBatch {
+  sourceId: number;
+  notes: string | null;
+}
+interface WritableChangemakerFieldValue {
+  changemakerId: number;
+  baseFieldShortCode: string;
+  batchId: number;
+  value: string;
+  goodAsOf: string | null;
+}
+
+const postChangemakerFieldValueBatch = (
+  baseUrl: string,
+  token: AccessTokenSet,
+  data: WritableChangemakerFieldValueBatch,
+) => (
+  callPdcApi<ChangemakerFieldValueBatch>(
+    baseUrl,
+    '/changemakerFieldValueBatches',
+    {},
+    'post',
+    token,
+    data,
+  )
+);
+
+const postChangemakerFieldValue = (
+  baseUrl: string,
+  token: AccessTokenSet,
+  data: WritableChangemakerFieldValue,
+) => (
+  callPdcApi<ChangemakerFieldValue>(
+    baseUrl,
+    '/changemakerFieldValues',
+    {},
+    'post',
+    token,
+    data,
   )
 );
 
@@ -83,8 +173,8 @@ const postPlatformProviderData = (
     baseUrl,
     '/platformProviderResponses',
     {},
-    token,
     'post',
+    token,
     {
       externalId,
       platformProvider,
@@ -94,7 +184,14 @@ const postPlatformProviderData = (
 );
 
 export {
+  ChangemakerFieldValue,
+  ChangemakerFieldValueBatch,
   getBaseFields,
+  getChangemakers,
   getProposals,
+  getSources,
+  postChangemakerFieldValueBatch,
+  postChangemakerFieldValue,
   postPlatformProviderData,
+  postSource,
 };


### PR DESCRIPTION
Point this script to a PDC instance with a Charity Navigator GraphQL API key and PDC Keycloak client/secret, and it will get changemakers from PDC, use (valid) EINs to fetch some data from Charity Navigator and post the results to ChangemakerFieldValues.

Issue #7 Make a charity navigator data import script