### PR TITLE
Update PDC API calls to use `BaseFieldsBundle`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "yargs": "^17.7.2"
       },
       "devDependencies": {
-        "@pdc/sdk": "^0.26.1",
+        "@pdc/sdk": "^0.35.1",
         "@types/node": "^24.12.2",
         "@types/yargs": "^17.0.32",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
@@ -264,9 +264,9 @@
       }
     },
     "node_modules/@pdc/sdk": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.26.1.tgz",
-      "integrity": "sha512-NT/qq/oHGD1izMgJWO3l6H0ClZS5uyD79ux7pgbxKTJERWhhLTGZ6Nfnck6c1xH1q1KWiO4HWZHMtWB1cBZ0xQ==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.35.1.tgz",
+      "integrity": "sha512-EWUU1NzCJYc6mx04SLmfYzQJHRBcVioQwjQ6N6nEW3td8368qH/qariLhxO9hl9WUlXpmn232zfExS7pSRheXQ==",
       "dev": true,
       "license": "AGPL-3.0"
     },
@@ -4766,9 +4766,9 @@
       }
     },
     "@pdc/sdk": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.26.1.tgz",
-      "integrity": "sha512-NT/qq/oHGD1izMgJWO3l6H0ClZS5uyD79ux7pgbxKTJERWhhLTGZ6Nfnck6c1xH1q1KWiO4HWZHMtWB1cBZ0xQ==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.35.1.tgz",
+      "integrity": "sha512-EWUU1NzCJYc6mx04SLmfYzQJHRBcVioQwjQ6N6nEW3td8368qH/qariLhxO9hl9WUlXpmn232zfExS7pSRheXQ==",
       "dev": true
     },
     "@pinojs/redact": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Open Tech Strategies",
   "license": "AGPL-3.0-or-later",
   "devDependencies": {
-    "@pdc/sdk": "^0.26.1",
+    "@pdc/sdk": "^0.35.1",
     "@types/node": "^24.12.2",
     "@types/yargs": "^17.0.32",
     "@typescript-eslint/eslint-plugin": "^5.62.0",

--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -2,6 +2,7 @@ import { client } from './client';
 import type { AccessTokenSet } from './oidc';
 import type {
   BaseField, ProposalBundle, ChangemakerBundle, SourceBundle, Source,
+  BaseFieldBundle,
 } from '@pdc/sdk';
 
 const callPdcApi = async <T>(
@@ -27,10 +28,13 @@ const callPdcApi = async <T>(
 };
 
 const getBaseFields = (baseUrl: string, token: AccessTokenSet) => (
-  callPdcApi<BaseField[]>(
+  callPdcApi<BaseFieldBundle>(
     baseUrl,
     '/baseFields',
-    {},
+    {
+      _page: '1',
+      _count: '2147483647',
+    },
     'get',
     token,
   )


### PR DESCRIPTION
The `GET /baseFields` structure changed. This updates the SDK and uses `BaseFieldsBundle`.

As it turns out, no code seems to be using this call, so nothing broke.